### PR TITLE
python 3 patch

### DIFF
--- a/unipath/abstractpath.py
+++ b/unipath/abstractpath.py
@@ -7,6 +7,12 @@ from unipath.errors import UnsafePathError
 
 __all__ = ["AbstractPath"]
 
+# Python3 compatability
+try:
+    unicode = unicode
+except NameError: # Python3 or no "unicode" support
+    unicode = str
+
 # Use unicode strings if possible
 _base = os.path.supports_unicode_filenames and unicode or str
 


### PR DESCRIPTION
Added a Python 3 code snippet to get the file to accept unicode naming when running Python 3.  This worked for me in my local project in a Python 3.4.0 environment.