### PR TITLE
PEP 519 Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Constructor
 ``Path`` (and ``AbstractPath``) objects can be created from a string path, or
 from several string arguments which are joined together a la ``os.path.join``.
 Each argument can be a string, an ``(Abstract)Path`` instance, an int or long,
-or a list/tuple of strings to be joined::
+a list/tuple of strings to be joined, or (Python 3.6+) a ``PathLike`` object::
 
     p = Path("foo/bar.py")       # A relative path
     p = Path("foo", "bar.py")    # Same as previous

--- a/test.py
+++ b/test.py
@@ -622,5 +622,29 @@ class TestHighLevel(FilesystemTest):
     # .write_file and .rmtree tested in .setUp.
 
 
+try:
+    from os import PathLike as _
+    pep519_present = True
+except ImportError:
+    pep519_present = False
 
-        
+
+@pytest.mark.skipif(not pep519_present, reason='PEP519 support not found')
+class TestPEP519(FilesystemTest):
+    # If PEP519 support is not present then interactions with other path-like objects are left undefined (will probably fail)
+
+    def test_pathlib(self):
+        import pathlib
+        pure_path = Path('a', 'b', Path('c'), Path('d'))
+        mixed_path = Path('a', pathlib.Path('b'), 'c', pathlib.Path('d'))
+        assert pure_path == mixed_path
+
+    def test_DirEntry(self):
+        d = self.d
+        with os.scandir(self.d) as it:
+            for entry in it:
+                pure_path = Path(self.d, entry.name, '..').resolve()
+                mixed_path = Path(entry, '..').resolve()
+                assert pure_path == mixed_path
+                return
+        assert False, "scandir() yielded an empty directory"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py36
 
 [testenv]
 deps=pytest

--- a/unipath/abstractpath.py
+++ b/unipath/abstractpath.py
@@ -25,6 +25,12 @@ try:
 except NameError:  # Python 3 doesn't have basestring nor long
     legal_arg_types = (str, list, int)
 
+try:
+    from os import PathLike
+    legal_arg_types += (PathLike,)
+except ImportError:
+    pass
+
 class AbstractPath(_base):
     """An object-oriented approach to os.path functions."""
     pathlib = os.path
@@ -54,6 +60,9 @@ class AbstractPath(_base):
         if resultStr is NotImplemented:
             return resultStr
         return self.__class__(resultStr)
+
+    def __fspath__(self):
+        return _base(self)
  
     @classmethod
     def _new_helper(class_, args):

--- a/unipath/abstractpath.py
+++ b/unipath/abstractpath.py
@@ -77,7 +77,7 @@ class AbstractPath(_base):
         args = list(args)
         for i, arg in enumerate(args):
             if not isinstance(arg, (AbstractPath,) + legal_arg_types):
-                m = "arguments must be str, unicode, list, int, long, or %s"
+                m = "arguments must be str, unicode, list, int, long, os.PathLike, or %s"
                 raise TypeError(m % class_.__name__)
             if isinstance(arg, int_types):
                 args[i] = str(arg)

--- a/unipath/abstractpath.py
+++ b/unipath/abstractpath.py
@@ -15,6 +15,16 @@ if os.path.supports_unicode_filenames:
     except NameError:
         pass
 
+try:
+    int_types = (int, long)
+except NameError:  # We are in Python 3
+    int_types = int
+
+try:
+    legal_arg_types = (basestring, list, int, long)
+except NameError:  # Python 3 doesn't have basestring nor long
+    legal_arg_types = (str, list, int)
+
 class AbstractPath(_base):
     """An object-oriented approach to os.path functions."""
     pathlib = os.path
@@ -55,19 +65,11 @@ class AbstractPath(_base):
         if len(args) == 1 and isinstance(args[0], class_) and \
             args[0].pathlib == pathlib:
             return args[0]
-        try:
-            legal_arg_types = (class_, basestring, list, int, long)
-        except NameError: # Python 3 doesn't have basestring nor long
-            legal_arg_types = (class_, str, list, int)
         args = list(args)
         for i, arg in enumerate(args):
-            if not isinstance(arg, legal_arg_types):
+            if not isinstance(arg, (AbstractPath,) + legal_arg_types):
                 m = "arguments must be str, unicode, list, int, long, or %s"
                 raise TypeError(m % class_.__name__)
-            try:
-                int_types = (int, long)
-            except NameError: # We are in Python 3
-                int_types = int
             if isinstance(arg, int_types):
                 args[i] = str(arg)
             elif isinstance(arg, class_) and arg.pathlib != pathlib:


### PR DESCRIPTION
Addresses #24 

- Now handles python 3.6 DirEntry and pathlib.Path
- AbstractPath probably doesn't need `__fspath__()` since it already extends `str` and anything handling `os.PathLike` probably has strings as a special case already (`isinstance('', os.PathLike)` is `False`), but I put it in there anyway
- Updated documentation (not that there's much to update) but didn't regenerate the html; no version bump -- I assume this would be part of a release/build step?

There is no special-case handling of `pathlib` or `DirEntry`, this is purely a PEP519 implementation (ie for python <3.6 things will continue to fail)