### PR TITLE
modified typo in README.html

### DIFF
--- a/README.html
+++ b/README.html
@@ -690,7 +690,7 @@ included.  'filter' must not be specified if 'names_only' is true.</p>
 <p class="last">Paths are returned in sorted order.</p>
 </dd>
 </dl>
-<p>.walk(pattern=None, filter=None, top_down=True)</p>
+<dt>.walk(pattern=None, filter=None, top_down=True)</dt>
 <blockquote>
 <p>Yield <tt class="docutils literal">FSPath</tt> objects for all files and directories under self,
 recursing subdirectories.  Paths are yielded in sorted order.</p>


### PR DESCRIPTION
Hi, 
I often use Unipath in my codes.
I think that the tag in README.html needs to be modified.
Thank you.